### PR TITLE
logwatch: provide logwatch configuration template

### DIFF
--- a/templates/check-mk/logwatch.cfg.j2
+++ b/templates/check-mk/logwatch.cfg.j2
@@ -1,41 +1,21 @@
-# +------------------------------------------------------------------+
-# |             ____ _               _        __  __ _  __           |
-# |            / ___| |__   ___  ___| | __   |  \/  | |/ /           |
-# |           | |   | '_ \ / _ \/ __| |/ /   | |\/| | ' /            |
-# |           | |___| | | |  __/ (__|   <    | |  | | . \            |
-# |            \____|_| |_|\___|\___|_|\_\___|_|  |_|_|\_\           |
-# |                                                                  |
-# | Copyright Mathias Kettner 2014             mk@mathias-kettner.de |
-# +------------------------------------------------------------------+
-#
-# This file is part of Check_MK.
-# The official homepage is at http://mathias-kettner.de/check_mk.
-#
-# check_mk is free software;  you can redistribute it and/or modify it
-# under the  terms of the  GNU General Public License  as published by
-# the Free Software Foundation in version 2.  check_mk is  distributed
-# in the hope that it will be useful, but WITHOUT ANY WARRANTY;  with-
-# out even the implied warranty of  MERCHANTABILITY  or  FITNESS FOR A
-# PARTICULAR PURPOSE. See the  GNU General Public License for more de-
-# tails. You should have  received  a copy of the  GNU  General Public
-# License along with GNU Make; see the file  COPYING.  If  not,  write
-# to the Free Software Foundation, Inc., 51 Franklin St,  Fifth Floor,
-# Boston, MA 02110-1301 USA.
+# Copyright (C) 2019 tribe29 GmbH - License: GNU General Public License v2
+# This file is part of Checkmk (https://checkmk.com). It is subject to the terms and
+# conditions defined in the file COPYING, which is part of this source code package.
 
 # logwatch.cfg
 # This file configures mk_logwatch. Define your logfiles
 # and patterns to be looked for here.
 
-# Name one or more logfiles
-/var/log/messages
+# Name one or more logfiles, and the options to be applied (if any)
+"/var/log/messages" maxlinesize=1024 encoding=utf-8
 # Patterns are indented with one space are prefixed with:
 # C: Critical messages
 # W: Warning messages
 # I: ignore these lines (OK)
-# R: Rewrite the output previous match. You can use \1, \2 etc. for refer to groups (.*) of this match
-# The first match decided. Lines that do not match any pattern
+# R: Rewrite the output previous match. You can use \1, \2 etc. for
+#    refer to groups (.*) of this match
+# The first match decides. Lines that do not match any pattern
 # are ignored
- I docker.*Error: the command \"get_roster\" requires 2 less argument
  C Fail event detected on md device
  I mdadm.*: Rebuild.*event detected
  W mdadm\[
@@ -45,11 +25,12 @@
  C device-mapper: thin:.*no free space
  C Error: (.*)
 
-/var/log/auth.log
+"/var/log/auth.log"
  W sshd.*Corrupted MAC on input
 
-/var/log/syslog /var/log/kern.log
+"/var/log/syslog" "/var/log/kern.log"
  I registered panic notifier
+ # additions by synpro:
  I panic=30
  I softdog: initialized. .*soft_panic
  I imap-login.*Oops
@@ -58,10 +39,13 @@
  I postfix/.*panic
  I spamd\[.*Oops
  I spamd\[.*panic
+ # upstream:
  C panic
  C Oops
+ # additions by synpro:
  C Cannot allocate memory
  C oom_kill_process
+ # upstream:
  W generic protection rip
  W .*Unrecovered read error - auto reallocate failed
 
@@ -74,5 +58,37 @@
  W reject: RCPT from .*mailin.fr.*blocked using zen.spamhaus.org
 
 # Globbing patterns are allowed:
-# /sapdata/*/saptrans.log
+# "/sapdata/*/saptrans.log"
 #  C ORA-
+
+# Quoting the filename is optional if it does not include spaces.
+# /var/log/syslog
+
+# Configuration of remote ips to a cluster name (refer to werk #7032 for more info):
+# - cluster name: A line containing "CLUSTER" defines the scope of a cluster mapping.
+#   For the logwatch configuration of a host several cluster configurations are allowed.
+#   The name of a cluster must follow in the same line as "CLUSTER" and must be separated
+#   with a single whitespace. The name must only consist of letters, digits, dash and
+#   underscore and it must start with a letter or underscore. All cluster mapping
+#   definitions in the logwatch configuration must have unique cluster names.
+# - ip addresses or subnets (CIDR notation): Lines defining an ip address or subnet in
+#   CIDR notation must begin with " ". IP addresses are
+#   determined by the Checkmk Agent and may be IPv4 addresses in IPv4 notation,
+#   IPv4 addresses extended to IPv6 notation and IPv6 addresses dependent on how the
+#   Checkmk Agent is accessed. However this configuration file expects IPv4 notation
+#   or IPv6 notation for cluster ip lookup. Subnets may be IPv4 or IPv6 CIDR notation.
+#
+# CLUSTER my_cluster
+#  192.168.1.1
+#  192.168.1.2
+#  192.168.1.3
+#  192.168.1.4
+#
+# CLUSTER another_cluster
+#  192.168.1.5
+#  192.168.1.6
+#  1762:0:0:0:0:B03:1:AF18
+#
+# CLUSTER yet_another_cluster
+#  192.168.1.0/24
+#  1762:0000:0000:0000:0000:0000:0000:0000/64


### PR DESCRIPTION
Based on upstream's
https://github.com/tribe29/checkmk/blame/master/agents/cfg_examples/logwatch.cfg /
https://raw.githubusercontent.com/tribe29/checkmk/master/agents/cfg_examples/logwatch.cfg
as of git rev e7e5fa5, with some custom changes that we adapted
over the last years.

Relevant changes from SynPro:

* On some of our systems, we use panic=30 as boot option, which triggers
  kernel messages like:

    kernel: [ 17.425970] softdog: initialized. soft_noboot=0 soft_margin=60 sec soft_panic=0 (nowayout=0)")

  Ignore `panic=30` and `softdog: initialized. .*soft_panic` accordingly.

* We need to ignore the "Oops" and "panic" strings also in mail related
  services like imap-login session names and postfix/smtpd /
  postfix/qmgr / postfix/pickup processes, as they way to often include
  message IDs, sessions names,... which trigger false positives, like:

    dovecot: imap-login: Login: user=<example>, method=PLAIN, rip=[...], lip=[...], mpid=1052, TLS, session=<cOOpSJ/Z9WQ0YeF1>

* `Cannot allocate memory` indicates an out of memory situation, as it
  was observed e.g. with failing xinetd forks under memory pressure:

    xinetd[818]: check_mk: fork failed: Cannot allocate memory (errno = 12)

* `oom_kill_process` indicates out of memory situations, like:

    kernel: [2203942.219394] Call Trace:
    [...]
    kernel: [2203942.219419]  [<ffffffff883894da>] ? oom_kill_process+0x22a/0x3f0
    kernel: [2203942.219421]  [<ffffffff88389971>] ? out_of_memory+0x111/0x470
    [...]

* `warning: /var/spool/postfix/etc/resolv.conf and /etc/resolv.conf differ`
  shows up, if postfix starts during bootup, before DNS configuration for
  /etc/resolv.conf finished, and postfix uses the chroot=y setting. Then
  the file /var/spool/postfix/etc/resolv.conf is empty, and sending mails
  doesn't work

* `dns.*failed: Connection refused` indicates that DNS configuration
  might be broken, as noticed with e.g. spamd:

    spamd[1331]: dns: sendto() to [127.0.0.1]:53 failed: Connection refused, failing over to [::1]:53
    spamd[1331]: dns: sendto() to [::1]:53 failed: Connection refused, failing over to [127.0.0.1]:53

* a message like `bayes: cannot open bayes databases` usually indicates
  permission issues, while we need to ignore `bayes: cannot open bayes
  databases /var/lib/spamassassin/.spamassassin/bayes_\* R/W: lock
  failed: File exists`, as this seems to be a race condition from
  spamassassin that we can't really do anything about

* the `reject: RCPT from .*mailin.fr.*blocked using zen.spamhaus.org`
  has been observed in the past with a mail server from the
  MailinBlue/mailin.fr newsletter service, which ended up on a blacklist.
  While blocking on postfix level using a service like zen.spamhaus.org might
  not be best practice, we'd like to be aware of this issue, and while
  this is customer specific, it shouldn't cause any harm on any systems.