### PR TITLE
logwatch.cfg.j2: disable "Corrupted MAC on input" for /var/log/auth.log

### DIFF
--- a/templates/check-mk/logwatch.cfg.j2
+++ b/templates/check-mk/logwatch.cfg.j2
@@ -25,8 +25,9 @@
  C device-mapper: thin:.*no free space
  C Error: (.*)
 
-"/var/log/auth.log"
- W sshd.*Corrupted MAC on input
+# Causes too many false positives
+#"/var/log/auth.log"
+# W sshd.*Corrupted MAC on input
 
 "/var/log/syslog" "/var/log/kern.log"
  I registered panic notifier


### PR DESCRIPTION
We have too many false positives at several of our customers, and decided to not enable this any longer. Backport internal change to our public ansible-role-checkmkagent.