### PR TITLE
logwatch.cfg.j2: check backup logs for pending tape drive cleanings

### DIFF
--- a/templates/check-mk/logwatch.cfg.j2
+++ b/templates/check-mk/logwatch.cfg.j2
@@ -58,6 +58,9 @@
  W bayes: cannot open bayes databases
  W reject: RCPT from .*mailin.fr.*blocked using zen.spamhaus.org
 
+/var/log/backup/backup_tape_latest
+ C The tape drive needs to be cleaned
+
 # Globbing patterns are allowed:
 # "/sapdata/*/saptrans.log"
 #  C ORA-


### PR DESCRIPTION
We usually symlink `/var/log/backup/backup_tape_latest` on our backup server to its latest backup execution log. If such a backup system uses tape drives underneath, they might require regular tape drive cleaning procedure, showing up in execution logs as:

```
TapeAlert[21]: Clean Periodic:The tape drive needs to be cleaned at next opportunity.
```

To be aware of such a situation, let's monitor it via logwatch.

FTR: non-existing log files don't seem to cause any problems with checkmk's logwatch, so until we have a better way to add custom snippets for specific systems, let's add it to our default template.