### PR TITLE
Migrate from xinetd to systemd by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,24 @@
 #
 
 # Set the version of the Check_Mk server
-checkmkagent_version: '2.0.0p30'
+checkmkagent_version: '2.2.0p9'
+
+# Force xinetd integration
+# If a host has xinetd installed and its xinetd binary is available, then
+# checkmk uses its integration. Only if systemd's systemctl is available and
+# the xinetd binary isn't available, then systemd integration gets enabled and
+# used.
+# We use systemd integration by default.
+# checkmkagent_service_xinetd: true | false(default)
+
+# Register checkmk agent for TLS
+# To register the checkmk agent for TLS checkmkagent 2.2.0 or higher needs to
+# be installed and `checkmkagent_site`, `checkmkagent_user`,
+# `checkmkagent_auth` + `checkmkagent_hostname` needs to be set.
+# checkmkagent_site: 'mysite'
+# checkmkagent_user: 'automation'
+# checkmkagent_auth: [ should be set in vault ]
+# checkmkagent_hostname: 'monitor01.example.com'
 
 # If `checkmkagent_host_url` is given the check-mk-agent package is
 # downloaded and deployed from the checkmk server: '{{ checkmkagent_host_url }}/check_mk/agents/check-mk-agent_{{ checkmkagent_version }}-1_all.deb'
@@ -11,9 +28,13 @@ checkmkagent_version: '2.0.0p30'
 # installed and the check-mk-agent package needs to be in `files/check-mk/`.
 # checkmkagent_host_url: 'http://monitor01.example.com/mysite'
 
-# To skip the installation of the check-mk-agent package from `files/check-mk/` set the following variable:
+# To skip the installation of the check-mk-agent package from `files/check-mk/`, set the following variable:
 # This is actually only useful for the ansible molecule tests.
 # checkmkagent_skip_install: true | false(default)
+
+# To skip enabling and starting of systemd service units, set the following variable:
+# This is actually only useful for the ansible molecule tests.
+# checkmkagent_skip_systemd: true | false(default)
 
 # Checkmk agent plugins will be deployed in the given path.
 # This usually should not be changed.

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,2 +1,12 @@
 ---
 # handlers file for ansible-role-checkmkagent
+
+- name: xinetd restart
+  ansible.builtin.service:
+    name: xinetd
+    state: restarted
+
+- name: cmk-agent-ctl-daemon restart
+  ansible.builtin.service:
+    name: cmk-agent-ctl-daemon
+    state: restarted

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,6 +5,8 @@
   ansible.builtin.service:
     name: xinetd
     state: restarted
+  register: xinetd_restarted
+  when: xinetd_check is succeeded
 
 - name: cmk-agent-ctl-daemon restart
   ansible.builtin.service:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -4,3 +4,4 @@
   roles:
     - role: jkirk.checkmkagent
       checkmkagent_skip_install: true
+      checkmkagent_skip_systemd: true

--- a/tasks/checkmkagent-disable-xinetd.yml
+++ b/tasks/checkmkagent-disable-xinetd.yml
@@ -1,0 +1,16 @@
+---
+- name: Ensure /etc/xinetd.d/check_mk is absent
+  file:
+    path: /etc/xinetd.d/check_mk
+    state: absent
+  register: checkmk_xinetd
+  notify: xinetd restart
+
+- name: Flush handlers
+  meta: flush_handlers
+
+- name: Ensure check-mk-agent port 6556 is closed
+  wait_for:
+    port: 6556
+    state: stopped
+  when: checkmk_xinetd.changed

--- a/tasks/checkmkagent-disable-xinetd.yml
+++ b/tasks/checkmkagent-disable-xinetd.yml
@@ -1,16 +1,22 @@
 ---
+- name: Check if xinetd is installed
+  command: dpkg-query -l xinetd
+  register: xinetd_check
+  changed_when: false
+  check_mode: false
+  ignore_errors: true
+
 - name: Ensure /etc/xinetd.d/check_mk is absent
   file:
     path: /etc/xinetd.d/check_mk
     state: absent
-  register: checkmk_xinetd
   notify: xinetd restart
 
 - name: Flush handlers
   meta: flush_handlers
 
-- name: Ensure check-mk-agent port 6556 is closed
+- name: Ensure check-mk-agent port 6556 is closed (after xinetd restart)
   wait_for:
     port: 6556
     state: stopped
-  when: checkmk_xinetd.changed
+  when: xinetd_restarted.changed|default(false)

--- a/tasks/checkmkagent-systemd.yml
+++ b/tasks/checkmkagent-systemd.yml
@@ -15,6 +15,17 @@
     - checkmkagent_hostname is defined and checkmkagent_hostname | length
   notify: cmk-agent-ctl-daemon restart
 
+- name: Ensure legacy checkmk agent services are stopped  + disabled
+  service:
+    name: "{{ item }}"
+    state: stopped
+    enabled: false
+  loop:
+    - check_mk.socket
+    - check_mk-async.service
+  when: not checkmkagent_skip_systemd|default(false)
+  register: checkmk_legacy_services_stopped
+
 - name: Ensure checkmk agent services are enabled + started
   service:
     name: "{{ item }}"
@@ -25,3 +36,13 @@
     - check-mk-agent.socket
     - cmk-agent-ctl-daemon.service
   when: not checkmkagent_skip_systemd|default(false)
+
+- name: Restart checkmk agent controller daemon (if xinetd was restarted and/or legacy services were stopped)
+  service:
+    name: "{{ item }}"
+    state: restarted
+  loop:
+    - cmk-agent-ctl-daemon.service
+  when:
+    - not checkmkagent_skip_systemd|default(false)
+    - checkmk_legacy_services_stopped.changed|default(false) or xinetd_restarted.changed|default(false)

--- a/tasks/checkmkagent-systemd.yml
+++ b/tasks/checkmkagent-systemd.yml
@@ -1,0 +1,36 @@
+---
+- name: Ensure /etc/xinetd.d/check_mk is absent
+  file:
+    path: /etc/xinetd.d/check_mk
+    state: absent
+  notify: xinetd restart
+
+- name: Flush handlers
+  meta: flush_handlers
+
+- name: Register checkmk agent for TLS
+  ansible.builtin.shell: |
+    cmk-agent-ctl register \
+      --server {{ checkmkagent_hostname }} \
+      --site {{ checkmkagent_site }} \
+      --user {{ checkmkagent_user }} \
+      --hostname {{ ansible_fqdn }} \
+      --password {{ checkmkagent_auth }} \
+      --trust-cert
+  when:
+    - checkmkagent_site is defined and checkmkagent_site | length
+    - checkmkagent_user is defined and checkmkagent_user | length
+    - checkmkagent_auth is defined and checkmkagent_auth | length
+    - checkmkagent_hostname is defined and checkmkagent_hostname | length
+  notify: cmk-agent-ctl-daemon restart
+
+- name: Ensure checkmk agent services are enabled + started
+  service:
+    name: "{{ item }}"
+    state: started
+    enabled: true
+  loop:
+    - check-mk-agent-async.service
+    - check-mk-agent.socket
+    - cmk-agent-ctl-daemon.service
+  when: not checkmkagent_skip_systemd|default(false)

--- a/tasks/checkmkagent-systemd.yml
+++ b/tasks/checkmkagent-systemd.yml
@@ -3,6 +3,7 @@
   file:
     path: /etc/xinetd.d/check_mk
     state: absent
+  register: checkmk_xinetd
   notify: xinetd restart
 
 - name: Flush handlers
@@ -23,6 +24,12 @@
     - checkmkagent_auth is defined and checkmkagent_auth | length
     - checkmkagent_hostname is defined and checkmkagent_hostname | length
   notify: cmk-agent-ctl-daemon restart
+
+- name: Ensure check-mk-agent port 6556 is closed
+  wait_for:
+    port: 6556
+    state: stopped
+  when: checkmk_xinetd.changed
 
 - name: Ensure checkmk agent services are enabled + started
   service:

--- a/tasks/checkmkagent-systemd.yml
+++ b/tasks/checkmkagent-systemd.yml
@@ -1,14 +1,4 @@
 ---
-- name: Ensure /etc/xinetd.d/check_mk is absent
-  file:
-    path: /etc/xinetd.d/check_mk
-    state: absent
-  register: checkmk_xinetd
-  notify: xinetd restart
-
-- name: Flush handlers
-  meta: flush_handlers
-
 - name: Register checkmk agent for TLS
   ansible.builtin.shell: |
     cmk-agent-ctl register \
@@ -24,12 +14,6 @@
     - checkmkagent_auth is defined and checkmkagent_auth | length
     - checkmkagent_hostname is defined and checkmkagent_hostname | length
   notify: cmk-agent-ctl-daemon restart
-
-- name: Ensure check-mk-agent port 6556 is closed
-  wait_for:
-    port: 6556
-    state: stopped
-  when: checkmk_xinetd.changed
 
 - name: Ensure checkmk agent services are enabled + started
   service:

--- a/tasks/deploy-checkmkagent.yml
+++ b/tasks/deploy-checkmkagent.yml
@@ -16,12 +16,11 @@
     owner: root
     group: root
     mode: 0644
-  when:
-    - checkmkagent_skip_install is undefined or not checkmkagent_skip_install
+  when: not checkmkagent_skip_install|default(false)
 
 - name: Deploy and install check-mk-agent package
   apt:
     deb: "/usr/lib/check_mk_agent/check-mk-agent_{{ checkmkagent_version }}-1_all.deb"
   when:
     - not ansible_check_mode
-    - checkmkagent_skip_install is undefined or not checkmkagent_skip_install
+    - not checkmkagent_skip_install|default(false)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,6 +54,9 @@
   include_tasks: deploy-checkmkagent.yml
   when: checkmkagent_host_url is not defined
 
+- include_tasks: checkmkagent-systemd.yml
+  when: not checkmkagent_service_xinetd|default(false)
+
 - include_tasks: checkmk-localchecks.yml
 - include_tasks: checkmk-plugins.yml
 - include_tasks: monitoring-megacli.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,6 +45,9 @@
 
 # tasks file for ansible-role-checkmkagent
 
+- include_tasks: checkmkagent-disable-xinetd.yml
+  when: not checkmkagent_service_xinetd|default(false)
+
 - name: Download and install check-mk-agent package
   apt:
     deb: "{{ checkmkagent_host_url }}/check_mk/agents/check-mk-agent_{{ checkmkagent_version }}-1_all.deb"


### PR DESCRIPTION
If a host has xinetd installed and its xinetd binary is available, then checkmk uses its integration. Only if systemd's systemctl is available and the xinetd binary isn't available, then systemd integration gets enabled and used.

So far, we have kept checkmk's default. Since upgrading to checkmk agent v2.2.0+, we decided to finally move to systemd integration. This will remove the xinetd configuration file that was deployed by the old "monitoring-client" role (and not by this role, in case anyone is looking for it).

Since Checkmk version 2.1.0 we the Agent Controller needs to register with the Agent Receiver. We can do that by setting `checkmkagent_site`, `checkmkagent_user`, `checkmkagent_auth` and `checkmkagent_hostname`.

We also make sure, that the systemd services `cmk-agent-ctl-daemon.service`, `check-mk-agent.socket` + `check-mk-agent-async.service` are enabled and started.

xinetd integration can be forced by setting the
variable "checkmkagent_service_xinetd: true".
Note, that the xinetd configuration will not be deployed and this only works if xinetd is installed.

Bumped the default checkmkagent_version to 2.2.0p9, our current latest checkmk version in use.

Closes: jkirk/ansible-role-checkmkagent#9