### PR TITLE
Add support for checkmk agent plugin mk_ceph.py

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,7 +43,7 @@ checkmkagent_plugins_path: "/usr/lib/check_mk_agent/plugins"
 
 # Currently the following checkmk agent plugins are supported:
 # (Don't override this variable!)
-checkmkagent_plugins_available: [ 'mk_ceph', 'mk_logwatch.py', 'mk_mysql', 'smart' ]
+checkmkagent_plugins_available: [ 'mk_ceph.py', 'mk_ceph', 'mk_logwatch.py', 'mk_mysql', 'smart' ]
 
 # Some plugins should only be deployed if explicitly requested.
 # The checkmk agent plugin mk_apt will be deployed always (on Debian hosts).

--- a/tasks/checkmk-plugins.yml
+++ b/tasks/checkmk-plugins.yml
@@ -107,14 +107,14 @@
     group: root
     mode: 0644
   when:
-    - checkmkagent_plugins_enabled | intersect( ['mk_ceph'] )
+    - checkmkagent_plugins_enabled | intersect( ['mk_ceph.py', 'mk_ceph'] )
 
 - name: Remove checkmk agent plugin mk_ceph config file
   file:
     path: '/etc/check_mk/ceph.cfg'
     state: absent
   when:
-    - not checkmkagent_plugins_enabled | intersect( ['mk_ceph'] )
+    - not checkmkagent_plugins_enabled | intersect( ['mk_ceph.py', 'mk_ceph'] )
 
 ### checkmk agent plugin: mk_logwatch
 


### PR DESCRIPTION
Since Checkmk 2.4.0b1 / Werk #17113 the "Ceph statistics" plugin mk_ceph.py was integrated and replaced the old "mk_ceph" plugin, see: https://checkmk.com/werk/17113

As long as this role supports older checkmk versions, it supports both checkmk agent plugins. The according plugin needs to be set in `checkmkagent_plugins_enabled`.

FTR:

The CheckMK agent plugins are all listed in
  CheckMK > Setup > Agents > Linux > Plugins

These plugins just can be retrieved via:
- {{ checkmkagent_host_url }}/check_mk/agents/plugins/{{ item }}
- /opt/omd/versions/{{ checkmkagent_version }}.cre/share/check_mk/agents/plugins/{{ item }}

A checkmk agent plugin needs to to the `checkmkagent_plugins_path` (`/usr/lib/check_mk_agent/plugins`) of the given host.

To deploy checkmk agent plugin the hosts variable
`checkmkagent_plugins_enabled` needs to set.
The plugin must be listed in the variable `checkmkagent_plugins_available`